### PR TITLE
Remove taint support

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1483,7 +1483,6 @@ prompt(int argc, VALUE *argv, VALUE io)
     if (argc > 0 && !NIL_P(argv[0])) {
 	VALUE str = argv[0];
 	StringValueCStr(str);
-	rb_check_safe_obj(str);
 	rb_io_write(io, str);
     }
 }


### PR DESCRIPTION
Ruby 2.7 deprecates taint and it no longer has an effect.
The lack of taint support should not cause a problem in
previous Ruby versions.