### PR TITLE
Use TCSANOW to prevent from discarding the input buffer

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -23,7 +23,7 @@ typedef struct termios conmode;
 static int
 setattr(int fd, conmode *t)
 {
-    while (tcsetattr(fd, TCSAFLUSH, t)) {
+    while (tcsetattr(fd, TCSANOW, t)) {
 	if (errno != EINTR) return 0;
     }
     return 1;


### PR DESCRIPTION
TCSAFLUSH discards the buffer read before the mode change, which makes
IRB ignore the buffer input immediately after invoked.  TCSANOW
preserves the buffer.