### PR TITLE
Use the C extension on truffleruby

### DIFF
--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -1,0 +1,25 @@
+name: truffleruby
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: [ 'truffleruby-head', 'truffleruby' ]
+    steps:
+    - name: git config
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+        git config --global advice.detachedHead 0
+    - uses: actions/checkout@master
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    - name: Run test
+      run: rake

--- a/.github/workflows/truffleruby.yml
+++ b/.github/workflows/truffleruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ 'truffleruby-head', 'truffleruby' ]
+        ruby: [ 'truffleruby-head' ]
     steps:
     - name: git config
       run: |

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/test_*.rb"]
 end
 
-if RUBY_ENGINE == "ruby"
+if RUBY_ENGINE == "ruby" || RUBY_ENGINE == "truffleruby"
   require 'rake/extensiontask'
   Rake::ExtensionTask.new(name)
   task :test => :compile

--- a/ext/io/console/extconf.rb
+++ b/ext/io/console/extconf.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 require 'mkmf'
 
-ok = true if RUBY_ENGINE == "ruby"
+ok = true if RUBY_ENGINE == "ruby" || RUBY_ENGINE == "truffleruby"
 hdr = nil
 case
 when macro_defined?("_WIN32", "")

--- a/lib/io/console.rb
+++ b/lib/io/console.rb
@@ -1,4 +1,4 @@
-if RUBY_ENGINE == 'ruby'
+if RUBY_ENGINE == 'ruby' || RUBY_ENGINE == 'truffleruby'
   require_relative 'console.so'
 else
   require_relative 'console/ffi/console'


### PR DESCRIPTION
Start using the C extension for TruffleRuby, and add a workflow to run the tests on the release and head versions.