### PR TITLE
Fix ArgumentError when IO.console receives keyword args

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -90,6 +90,10 @@ extern VALUE rb_scheduler_timeout(struct timeval *timeout);
 #define sys_fail_fptr(fptr) rb_sys_fail_str((fptr)->pathv)
 
 #ifndef HAVE_RB_F_SEND
+#ifndef RB_PASS_CALLED_KEYWORDS
+# define rb_funcallv_kw(recv, mid, arg, argv, kw_splat) rb_funcallv(recv, mid, arg, argv)
+#endif
+
 static ID id___send__;
 
 static VALUE
@@ -104,7 +108,7 @@ rb_f_send(int argc, VALUE *argv, VALUE recv)
     else {
 	vid = id___send__;
     }
-    return rb_funcallv(recv, vid, argc, argv);
+    return rb_funcallv_kw(recv, vid, argc, argv, RB_PASS_CALLED_KEYWORDS);
 }
 #endif
 

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -401,6 +401,10 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
       assert_equal(["true"], run_pty("IO.console(:close); p IO.console(:tty?)"))
     end
 
+    def test_console_kw
+      assert_equal(["File"], run_pty("IO.console.close; p IO.console(:clone, freeze: true).class"))
+    end
+
     def test_sync
       assert_equal(["true"], run_pty("p IO.console.sync"))
     end
@@ -475,6 +479,10 @@ defined?(IO.console) and TestIO_Console.class_eval do
       assert(IO.console(:tty?))
     ensure
       IO.console(:close)
+    end
+
+    def test_console_kw
+      assert_kind_of(IO, IO.console(:clone, freeze: true))
     end
 
     def test_sync


### PR DESCRIPTION
`IO.console` method raises an ArgumentError when it receives keyword arguments due to the Ruby 3 keyword args change. For example:


```console
$ docker run -it --rm rubylang/all-ruby env ALL_RUBY_SINCE=2.4 ./all-ruby -r io/console -e 'IO.console(:clone, freeze: true)'
ruby-2.4.0          
...
ruby-2.7.0-preview1 
ruby-2.7.0-preview2 -e:1: warning: The last argument is used as the keyword parameter
...
ruby-2.7.0-rc1      -e:1: warning: The last argument is used as the keyword parameter
ruby-2.7.0-rc2      -e:1: warning: The last argument is used as keyword parameters
ruby-2.7.0          -e:1: warning: Using the last argument as keyword parameters is deprecated
...
ruby-2.7.4          -e:1: warning: Using the last argument as keyword parameters is deprecated
ruby-3.0.0-preview1 <internal:kernel>:47:in `clone': wrong number of arguments (given 1, expected 0) (ArgumentError)
                    	from -e:1:in `console'
                    	from -e:1:in `<main>'
                exit 1
...
ruby-3.0.2          <internal:kernel>:47:in `clone': wrong number of arguments (given 1, expected 0) (ArgumentError)
                    	from -e:1:in `console'
                    	from -e:1:in `<main>'
                exit 1
```


This patch fixes the problem.