### PR TITLE
Fix `Leaked file descriptor: TestIO_Console#test_console_kw`

### DIFF
--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -488,7 +488,9 @@ defined?(IO.console) and TestIO_Console.class_eval do
     end
 
     def test_console_kw
-      assert_kind_of(IO, IO.console(:clone, freeze: true))
+      io = IO.console(:clone, freeze: true)
+      io.close
+      assert_kind_of(IO, io)
     end
 
     def test_sync


### PR DESCRIPTION
Synchronize a test changed in ruby core.
see https://github.com/ruby/ruby/commit/d5836db1b398a7936b0461b3011db66f6cc8c490
