### PR TITLE
Support native console in linux aarch64 for JRuby

### DIFF
--- a/lib/io/console/ffi/linux_console.rb
+++ b/lib/io/console/ffi/linux_console.rb
@@ -1,6 +1,8 @@
 require 'ffi'
 
-raise LoadError.new("native console only supported on i386, x86_64 and powerpc64") unless FFI::Platform::ARCH =~ /i386|x86_64|powerpc64/
+unless FFI::Platform::ARCH =~ /i386|x86_64|powerpc64|aarch64/
+  raise LoadError.new("native console only supported on i386, x86_64, powerpc64 and aarch64")
+end
 
 module IO::LibC
   extend FFI::Library


### PR DESCRIPTION
I am running JRuby on a Linux aarch64.

I can see the `io/console/ffi/stty_console` is being loaded based on the warning message:
"io/console on JRuby shells out to stty for most operations"

If I manually require `io/console/ffi/native_console` it fails due to the platform guard at the top of the file.

However, if I remove that guard it, it loads and works fine in my brief testing.

In #40, @headius confirmed there is no reason not to allow aarch64, so adding it in this PR. Closes #40.