### PR TITLE
Fix `IO.console_size` to work when `IO.console` is not available

### DIFF
--- a/lib/io/console/size.rb
+++ b/lib/io/console/size.rb
@@ -16,8 +16,8 @@ rescue LoadError
 else
   # returns console window size
   def IO.console_size
-    console.winsize
+    IO.console.winsize
   rescue NoMethodError
-    default_console_size
+    IO.default_console_size
   end
 end


### PR DESCRIPTION
At the moment, this works correctly when `console` method exists, but when it doesn't exist it actually fails with NameError instead of NoMethodError.

For example, when using JRuby on Linux aarch64 (related #40): (trimmed IRB output)
```
io/console on JRuby shells out to stty for most operations
irb(main):001:0> IO.console
(irb):1:in `evaluate': undefined method `console' for IO:Class (NoMethodError)
irb(main):003:0> require 'io/console/size'
irb(main):004:0> IO.console_size
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/io/console/size.rb:19:in `console_size': undefined local variable or method `console' for IO:Class (NameError)
```

With the change in this PR it works as expected.