### PR TITLE
[DOC] IO::console.getpass usage example

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1578,6 +1578,12 @@ str_chomp(VALUE str)
  * see String#chomp!.
  *
  * You must require 'io/console' to use this method.
+ * 
+ *    require 'io/console'
+ *    IO::console.getpass("Enter password: ")
+ *    Enter password: 
+ *    # => "mypassword"
+ * 
  */
 static VALUE
 console_getpass(int argc, VALUE *argv, VALUE io)


### PR DESCRIPTION
There were no clear example of this very useful method's usage anywhere in the `IO` or `IO::Console` docs, which was a shame.

Originally opened as https://github.com/ruby/ruby/pull/8241