### PR TITLE
enable s390x for jruby

### DIFF
--- a/lib/io/console/ffi/linux_console.rb
+++ b/lib/io/console/ffi/linux_console.rb
@@ -1,7 +1,7 @@
 require 'ffi'
 
-unless FFI::Platform::ARCH =~ /i386|x86_64|powerpc64|aarch64/
-  raise LoadError.new("native console only supported on i386, x86_64, powerpc64 and aarch64")
+unless FFI::Platform::ARCH =~ /i386|x86_64|powerpc64|aarch64|s390x/
+  raise LoadError.new("native console only supported on i386, x86_64, powerpc64, aarch64 and s390x")
 end
 
 module IO::LibC


### PR DESCRIPTION
fixes: https://github.com/jruby/jruby/issues/8005

jruby 9.4.6.0-SNAPSHOT (3.1.4) 2023-11-06 c448bd58dd OpenJDK 64-Bit Server VM 11.0.20.1+1-post-Ubuntu-0ubuntu122.04 on 11.0.20.1+1-post-Ubuntu-0ubuntu122.04 +jit [s390x-linux]

![obrazek](https://github.com/ruby/io-console/assets/9540855/5306a04c-a600-4aaf-bdc7-b627bae9e8a3)
