### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/io-console

### DIFF
--- a/io-console.gemspec
+++ b/io-console.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.6.0"
   s.homepage = "https://github.com/ruby/io-console"
   s.metadata["source_code_url"] = s.homepage
+  s.metadata["changelog_uri"] = s.homepage + "/releases"
   s.authors = ["Nobu Nakada"]
   s.require_path = %[lib]
   s.files = %w[


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/io-console which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/