### PR TITLE
Define IO::ConsoleMode::VERSION from console.c

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -2,6 +2,10 @@
 /*
  * console IO module
  */
+
+static const char *const
+IO_CONSOLE_VERSION = "0.7.2.dev.1";
+
 #include "ruby.h"
 #include "ruby/io.h"
 #include "ruby/thread.h"

--- a/ext/io/console/extconf.rb
+++ b/ext/io/console/extconf.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: false
 require 'mkmf'
 
-version = ["../../..", "."].find do |dir|
-  break File.read(File.join(__dir__, dir, "io-console.gemspec"))[/^_VERSION\s*=\s*"(.*?)"/, 1]
-rescue
-end
-
 have_func("rb_io_path")
 have_func("rb_io_descriptor")
 have_func("rb_io_get_write_io")
@@ -40,7 +35,6 @@ when true
   elsif have_func("rb_scheduler_timeout") # 3.0
     have_func("rb_io_wait")
   end
-  $defs << "-D""IO_CONSOLE_VERSION=#{version}"
   create_makefile("io/console") {|conf|
     conf << "\n""VK_HEADER = #{vk_header}\n"
   }

--- a/io-console.gemspec
+++ b/io-console.gemspec
@@ -1,5 +1,13 @@
 # -*- ruby -*-
-_VERSION = "0.7.2.dev.1"
+_VERSION = ["", "ext/io/console/"].find do |dir|
+  begin
+    break File.open(File.join(__dir__, "#{dir}console.c")) {|f|
+      f.gets("\nIO_CONSOLE_VERSION ")
+      f.gets[/"(.+)"/, 1]
+    }
+  rescue Errno::ENOENT
+  end
+end
 
 Gem::Specification.new do |s|
   s.name = "io-console"


### PR DESCRIPTION
Because io-console.gemspec is loaded in extconf.rb.
`IO::ConsoleMode::VERSION` is empty in gem installed io-console.

```
❯ irb
irb(main):001> require 'io/console'
=> false
irb(main):002> IO::ConsoleMode::VERSION
=> ""

irb(main):003> irb_info
Ruby version: 3.3.0
IRB version: irb 1.11.0 (2023-12-19)
InputMethod: RelineInputMethod with Reline 0.4.1
Completion: Autocomplete, ReplTypeCompletor: 0.1.2, Prism: 0.19.0, RBS: 3.4.0
.irbrc path: /Users/mi/.irbrc
RUBY_PLATFORM: x86_64-darwin21
East Asian Ambiguous Width: 1
=> nil
```