### PR TITLE
Handle Errno::EOPNOTSUPP errors

### DIFF
--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -37,7 +37,7 @@ class TestIO_Console < Test::Unit::TestCase
     trap(:TTOU, @old_ttou) if defined?(@old_ttou) and @old_ttou
   end
 
-  exceptions = %w[ENODEV ENOTTY EBADF ENXIO].map {|e|
+  exceptions = %w[ENODEV ENOTTY EBADF ENXIO EOPNOTSUPP].map {|e|
     Errno.const_get(e) if Errno.const_defined?(e)
   }
   exceptions.compact!


### PR DESCRIPTION
OpenBSD can raise this error in TestIO_Console#test_failed_path.