### PR TITLE
Support older versions of ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
+      min_version: 2.6 # from `required_ruby_version` in io-console.gemspec
 
   test:
     needs: ruby-versions

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1598,14 +1598,14 @@ console_dev_remove(VALUE klass)
 
 static ID id_console;
 
-static bool
+static int
 console_dev_get(VALUE klass, VALUE *dev)
 {
     if (rb_const_defined(klass, id_console)) {
 	*dev = rb_const_get(klass, id_console);
-	return true;
+	return 1;
     }
-    return false;
+    return 0;
 }
 
 static void

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -1538,10 +1538,8 @@ console_clear_screen(VALUE io)
 static VALUE
 io_open_descriptor_fallback(VALUE klass, int descriptor, int mode, VALUE path, VALUE timeout, void *encoding)
 {
-    rb_update_max_fd(descriptor);
-
     VALUE arguments[2] = {
-        INT2NUM(descriptor),
+        (rb_update_max_fd(descriptor), INT2NUM(descriptor)),
         INT2FIX(mode),
     };
 


### PR DESCRIPTION
The minimum `required_ruby_version` is still 2.6.0.