### PR TITLE
Read errno before calling rb_io_path()

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -125,7 +125,10 @@ io_get_write_io_fallback(VALUE io)
 #define rb_io_get_write_io io_get_write_io_fallback
 #endif
 
-#define sys_fail(io) rb_sys_fail_str(rb_io_path(io))
+#define sys_fail(io) do { \
+    int err = errno; \
+    rb_syserr_fail_str(err, rb_io_path(io)); \
+} while (0)
 
 #ifndef HAVE_RB_F_SEND
 #ifndef RB_PASS_CALLED_KEYWORDS


### PR DESCRIPTION
Possible fix for recent crashes seen on CI.

     [BUG] rb_sys_fail_str(<STDIN>) - errno == 0

rb_io_path() calls rb_obj_dup(), which could call initialize_dup in Ruby and clobber errno before rb_sys_fail_str() gets to read errno. So save it out first.

(Using separate statements because order of evaluation in function call list is unspecified, and order is important here.)