### PR TITLE
Check if `rb_syserr_fail_str` is available

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -125,6 +125,10 @@ io_get_write_io_fallback(VALUE io)
 #define rb_io_get_write_io io_get_write_io_fallback
 #endif
 
+#ifndef DHAVE_RB_SYSERR_FAIL_STR
+# define rb_syserr_fail_str(e, mesg) rb_exc_raise(rb_syserr_new_str(e, mesg))
+#endif
+
 #define sys_fail(io) do { \
     int err = errno; \
     rb_syserr_fail_str(err, rb_io_path(io)); \

--- a/ext/io/console/extconf.rb
+++ b/ext/io/console/extconf.rb
@@ -5,6 +5,10 @@ require 'mkmf'
 # See https://bugs.ruby-lang.org/issues/20345
 MakeMakefile::RbConfig ||= ::RbConfig
 
+have_func("rb_syserr_fail_str(0, Qnil)") or
+have_func("rb_syserr_new_str(0, Qnil)") or
+  abort
+
 have_func("rb_io_path")
 have_func("rb_io_descriptor")
 have_func("rb_io_get_write_io")


### PR DESCRIPTION
Truffle ruby seems to lack it.