### PR TITLE
Ignore `^C` at interrupt test

### DIFF
--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -367,6 +367,7 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
     w.print cc
     w.flush
     result = EnvUtil.timeout(3) {r.gets}
+    result = yield result if defined?(yield)
     assert_equal(expect, result.chomp)
   end
 
@@ -404,7 +405,7 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
       if cc = ctrl["intr"]
         assert_ctrl("#{cc.ord}", cc, r, w)
         assert_ctrl("#{cc.ord}", cc, r, w)
-        assert_ctrl("Interrupt", cc, r, w) unless /linux/ =~ RUBY_PLATFORM
+        assert_ctrl("Interrupt", cc, r, w) {|res| res.sub("^C", "")} unless /linux/ =~ RUBY_PLATFORM
       end
       if cc = ctrl["dsusp"]
         assert_ctrl("#{cc.ord}", cc, r, w)

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -542,9 +542,7 @@ defined?(IO.console) and TestIO_Console.class_eval do
       File.open(ttyname) {|f| assert_predicate(f, :tty?)}
     end
   end
-end
 
-defined?(IO.console) and TestIO_Console.class_eval do
   case
   when Process.respond_to?(:daemon)
     noctty = [EnvUtil.rubybin, "-e", "Process.daemon(true)"]


### PR DESCRIPTION
It's something we don't expect and might be coming from somewhere else.
