### PR TITLE
Fix removing unexpected control chars

### DIFF
--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -373,10 +373,10 @@ defined?(PTY) and defined?(IO.console) and TestIO_Console.class_eval do
     w.flush
     result = EnvUtil.timeout(3) {r.gets}
     if result
-      case cc
-      when 0..31
+      case cc.chr
+      when "\C-A".."\C-_"
         cc = "^" + (cc.ord | 0x40).chr
-      when 127
+      when "\C-?"
         cc = "^?"
       end
       result.sub!(cc, "")


### PR DESCRIPTION
`cc` is created as `"\C-x"`, it is a String since ruby 1.9.