### PR TITLE
CI: Pin rbs on JRuby to a pre-release with JRuby support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,10 @@ gemspec
 group :development do
   gem "bundler"
   gem "rake"
-  gem "rdoc"
   gem "test-unit"
   gem "test-unit-ruby-core"
   gem 'rake-compiler'
+
+  # RDoc 8 pulls in RBS 4, which attempts to build a native extension on JRuby.
+  gem 'rdoc', (RUBY_ENGINE == 'jruby' ? '< 8' : nil)
 end

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,13 @@ gemspec
 group :development do
   gem "bundler"
   gem "rake"
+  gem "rdoc"
+
+  # rdoc 8 depends on rbs, which has no java platform gem before 4.1.0.pre.2.
+  # See https://github.com/ruby/rdoc/issues/1746
+  gem 'rbs', '>= 4.1.0.pre.2' if RUBY_PLATFORM == 'java'
+
   gem "test-unit"
   gem "test-unit-ruby-core"
   gem 'rake-compiler'
-
-  # RDoc 8 pulls in RBS 4, which attempts to build a native extension on JRuby.
-  gem 'rdoc', (RUBY_ENGINE == 'jruby' ? '< 8' : nil)
 end


### PR DESCRIPTION
Related to https://github.com/ruby/rdoc/issues/1746

This PR tries to get to green for JRuby for this repo.

First, I pinned to an older rdoc for JRuby.

Then, I learned that perhaps it'd be better to:

```ruby
  # rdoc 8 depends on rbs, which has no java platform gem before 4.1.0.pre.2.
  # See https://github.com/ruby/rdoc/issues/1746
  gem 'rbs', '>= 4.1.0.pre.2' if RUBY_PLATFORM == 'java'
```