### PR TITLE
Make win32_vk generator portable to cmd.exe

### DIFF
--- a/ext/io/console/depend
+++ b/ext/io/console/depend
@@ -2,10 +2,7 @@ win32_vk.inc: win32_vk.list
 
 .list.inc:
 	( \
-	$(RUBY) -anF, \
-	-e 'BEGIN {puts "#define UNDEFINED_VK (unsigned short)-1"}' \
-	-e 'n=$$F[1] and (n.strip!; /\AVK_/=~n) and' \
-	-e   'puts(%[#ifndef #{n}\n# define #{n} UNDEFINED_VK\n#endif])' \
+	$(RUBY) -e "ARGF.read.scan(/^\w+,\s*\KVK_\w+/){|n|puts(%Q[#ifndef #{n}\n# define #{n} UNDEFINED_VK\n#endif])}" \
 	$< && \
 	gperf --ignore-case -L ANSI-C -E -C -P -p -j1 -i 1 -g -o -t -K ofs -N console_win32_vk -k* $< \
 	| sed -f $(top_srcdir)/tool/gperf.sed \

--- a/ext/io/console/win32_vk.chksum
+++ b/ext/io/console/win32_vk.chksum
@@ -1,1 +1,1 @@
-src="win32_vk.list", len=3269, checksum=34076
+src="win32_vk.list", len=3352, checksum=39855

--- a/ext/io/console/win32_vk.inc
+++ b/ext/io/console/win32_vk.inc
@@ -1,4 +1,3 @@
-#define UNDEFINED_VK (unsigned short)-1
 #ifndef VK_LBUTTON
 # define VK_LBUTTON UNDEFINED_VK
 #endif
@@ -479,7 +478,7 @@
 #ifndef VK_OEM_CLEAR
 # define VK_OEM_CLEAR UNDEFINED_VK
 #endif
-/* ANSI-C code produced by gperf version 3.1 */
+/* ANSI-C code produced by gperf version 3.3 */
 /* Command-line: gperf --ignore-case -L ANSI-C -E -C -P -p -j1 -i 1 -g -o -t -K ofs -N console_win32_vk -k'*' win32_vk.list  */
 
 #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
@@ -511,15 +510,16 @@
 
 #line 1 "win32_vk.list"
 
+#define UNDEFINED_VK (unsigned short)-1
 struct vktable {short ofs; unsigned short vk;};
 static const struct vktable *console_win32_vk(const char *, size_t);
-#line 5 "win32_vk.list"
+#line 6 "win32_vk.list"
 struct vktable;
 /* maximum key range = 245, duplicates = 0 */
 
 #ifndef GPERF_DOWNCASE
 #define GPERF_DOWNCASE 1
-static unsigned char gperf_downcase[256] =
+static const unsigned char gperf_downcase[256] =
   {
       0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,
      15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,
@@ -603,57 +603,147 @@ hash (register const char *str, register size_t len)
     {
       default:
         hval += asso_values[(unsigned char)str[18]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 18:
         hval += asso_values[(unsigned char)str[17]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 17:
         hval += asso_values[(unsigned char)str[16]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 16:
         hval += asso_values[(unsigned char)str[15]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 15:
         hval += asso_values[(unsigned char)str[14]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 14:
         hval += asso_values[(unsigned char)str[13]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 13:
         hval += asso_values[(unsigned char)str[12]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 12:
         hval += asso_values[(unsigned char)str[11]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 11:
         hval += asso_values[(unsigned char)str[10]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 10:
         hval += asso_values[(unsigned char)str[9]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 9:
         hval += asso_values[(unsigned char)str[8]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 8:
         hval += asso_values[(unsigned char)str[7]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 7:
         hval += asso_values[(unsigned char)str[6]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 6:
         hval += asso_values[(unsigned char)str[5]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 5:
         hval += asso_values[(unsigned char)str[4]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 4:
         hval += asso_values[(unsigned char)str[3]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 3:
         hval += asso_values[(unsigned char)str[2]+2];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 2:
         hval += asso_values[(unsigned char)str[1]];
+#if (defined __cplusplus && (__cplusplus >= 201703L || (__cplusplus >= 201103L && defined __clang__ && __clang_major__ + (__clang_minor__ >= 9) > 3))) || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 202000L && ((defined __GNUC__ && __GNUC__ >= 10) || (defined __clang__ && __clang_major__ >= 9)))
+      [[fallthrough]];
+#elif (defined __GNUC__ && __GNUC__ >= 7) || (defined __clang__ && __clang_major__ >= 10)
+      __attribute__ ((__fallthrough__));
+#endif
       /*FALLTHROUGH*/
       case 1:
         hval += asso_values[(unsigned char)str[0]];
@@ -1001,374 +1091,381 @@ console_win32_vk (register const char *str, register size_t len)
       MAX_HASH_VALUE = 256
     };
 
+#if (defined __GNUC__ && __GNUC__ + (__GNUC_MINOR__ >= 6) > 4) || (defined __clang__ && __clang_major__ >= 3)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
   static const struct vktable wordlist[] =
     {
       {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
       {-1}, {-1}, {-1},
-#line 40 "win32_vk.list"
+#line 41 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str12, VK_UP},
-#line 52 "win32_vk.list"
+#line 53 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str13, VK_APPS},
-#line 159 "win32_vk.list"
+#line 160 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str14, VK_CRSEL},
-#line 34 "win32_vk.list"
+#line 35 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str15, VK_SPACE},
-#line 95 "win32_vk.list"
+#line 96 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str16, VK_SCROLL},
-#line 29 "win32_vk.list"
+#line 30 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str17, VK_ESCAPE},
-#line 9 "win32_vk.list"
+#line 10 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str18, VK_CANCEL},
-#line 32 "win32_vk.list"
+#line 33 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str19, VK_ACCEPT},
-#line 66 "win32_vk.list"
+#line 67 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str20, VK_SEPARATOR},
-#line 43 "win32_vk.list"
+#line 44 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str21, VK_SELECT},
-#line 18 "win32_vk.list"
+#line 19 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str22, VK_CONTROL},
-#line 166 "win32_vk.list"
+#line 167 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str23, VK_OEM_CLEAR},
-#line 145 "win32_vk.list"
+#line 146 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str24, VK_OEM_RESET},
-#line 155 "win32_vk.list"
+#line 156 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str25, VK_OEM_AUTO},
-#line 151 "win32_vk.list"
+#line 152 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str26, VK_OEM_CUSEL},
       {-1},
-#line 22 "win32_vk.list"
+#line 23 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str28, VK_KANA},
-#line 127 "win32_vk.list"
+#line 128 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str29, VK_OEM_PLUS},
-#line 35 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str30, VK_PRIOR},
-#line 152 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str31, VK_OEM_ATTN},
-#line 20 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str32, VK_PAUSE},
-#line 13 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str33, VK_BACK},
-#line 144 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str34, VK_PACKET},
-#line 105 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str35, VK_RCONTROL},
-#line 104 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str36, VK_LCONTROL},
-#line 37 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str37, VK_END},
-#line 38 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str38, VK_HOME},
-#line 44 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str39, VK_PRINT},
-#line 94 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str40, VK_NUMLOCK},
-#line 39 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str41, VK_LEFT},
-#line 25 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str42, VK_JUNJA},
-#line 19 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str43, VK_MENU},
-#line 150 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str44, VK_OEM_WSCTRL},
-#line 156 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str45, VK_OEM_ENLW},
 #line 36 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str46, VK_NEXT},
-#line 51 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str47, VK_RWIN},
-#line 50 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str48, VK_LWIN},
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str30, VK_PRIOR},
+#line 153 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str31, VK_OEM_ATTN},
 #line 21 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str32, VK_PAUSE},
+#line 14 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str33, VK_BACK},
+#line 145 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str34, VK_PACKET},
+#line 106 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str35, VK_RCONTROL},
+#line 105 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str36, VK_LCONTROL},
+#line 38 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str37, VK_END},
+#line 39 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str38, VK_HOME},
+#line 45 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str39, VK_PRINT},
+#line 95 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str40, VK_NUMLOCK},
+#line 40 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str41, VK_LEFT},
+#line 26 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str42, VK_JUNJA},
+#line 20 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str43, VK_MENU},
+#line 151 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str44, VK_OEM_WSCTRL},
+#line 157 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str45, VK_OEM_ENLW},
+#line 37 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str46, VK_NEXT},
+#line 52 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str47, VK_RWIN},
+#line 51 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str48, VK_LWIN},
+#line 22 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str49, VK_CAPITAL},
-#line 49 "win32_vk.list"
+#line 50 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str50, VK_HELP},
-#line 164 "win32_vk.list"
+#line 165 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str51, VK_NONAME},
-#line 8 "win32_vk.list"
+#line 9 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str52, VK_RBUTTON},
-#line 7 "win32_vk.list"
+#line 8 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str53, VK_LBUTTON},
-#line 96 "win32_vk.list"
+#line 97 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str54, VK_OEM_NEC_EQUAL},
       {-1},
-#line 47 "win32_vk.list"
+#line 48 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str56, VK_INSERT},
-#line 27 "win32_vk.list"
+#line 28 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str57, VK_HANJA},
       {-1}, {-1},
-#line 46 "win32_vk.list"
+#line 47 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str60, VK_SNAPSHOT},
-#line 158 "win32_vk.list"
+#line 159 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str61, VK_ATTN},
-#line 14 "win32_vk.list"
+#line 15 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str62, VK_TAB},
-#line 157 "win32_vk.list"
+#line 158 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str63, VK_OEM_BACKTAB},
-#line 143 "win32_vk.list"
+#line 144 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str64, VK_ICO_CLEAR},
-#line 30 "win32_vk.list"
+#line 31 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str65, VK_CONVERT},
-#line 16 "win32_vk.list"
+#line 17 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str66, VK_RETURN},
-#line 146 "win32_vk.list"
+#line 147 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str67, VK_OEM_JUMP},
       {-1}, {-1}, {-1},
-#line 111 "win32_vk.list"
+#line 112 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str71, VK_BROWSER_STOP},
-#line 26 "win32_vk.list"
+#line 27 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str72, VK_FINAL},
-#line 163 "win32_vk.list"
+#line 164 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str73, VK_ZOOM},
-#line 28 "win32_vk.list"
+#line 29 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str74, VK_KANJI},
-#line 48 "win32_vk.list"
+#line 49 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str75, VK_DELETE},
-#line 128 "win32_vk.list"
+#line 129 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str76, VK_OEM_COMMA},
-#line 67 "win32_vk.list"
+#line 68 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str77, VK_SUBTRACT},
       {-1},
-#line 10 "win32_vk.list"
+#line 11 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str79, VK_MBUTTON},
-#line 78 "win32_vk.list"
+#line 79 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str80, VK_F9},
-#line 17 "win32_vk.list"
+#line 18 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str81, VK_SHIFT},
-#line 103 "win32_vk.list"
+#line 104 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str82, VK_RSHIFT},
-#line 102 "win32_vk.list"
+#line 103 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str83, VK_LSHIFT},
-#line 65 "win32_vk.list"
+#line 66 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str84, VK_ADD},
-#line 31 "win32_vk.list"
+#line 32 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str85, VK_NONCONVERT},
-#line 160 "win32_vk.list"
+#line 161 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str86, VK_EXSEL},
-#line 126 "win32_vk.list"
+#line 127 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str87, VK_OEM_1},
-#line 138 "win32_vk.list"
+#line 139 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str88, VK_OEM_AX},
-#line 108 "win32_vk.list"
+#line 109 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str89, VK_BROWSER_BACK},
-#line 137 "win32_vk.list"
+#line 138 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str90, VK_OEM_8},
-#line 129 "win32_vk.list"
+#line 130 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str91, VK_OEM_MINUS},
-#line 162 "win32_vk.list"
+#line 163 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str92, VK_PLAY},
-#line 131 "win32_vk.list"
+#line 132 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str93, VK_OEM_2},
-#line 15 "win32_vk.list"
+#line 16 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str94, VK_CLEAR},
-#line 99 "win32_vk.list"
+#line 100 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str95, VK_OEM_FJ_TOUROKU},
-#line 147 "win32_vk.list"
+#line 148 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str96, VK_OEM_PA1},
-#line 140 "win32_vk.list"
+#line 141 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str97, VK_ICO_HELP},
-#line 112 "win32_vk.list"
+#line 113 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str98, VK_BROWSER_SEARCH},
-#line 53 "win32_vk.list"
+#line 54 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str99, VK_SLEEP},
       {-1},
-#line 70 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str101, VK_F1},
-#line 148 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str102, VK_OEM_PA2},
-#line 154 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str103, VK_OEM_COPY},
-#line 77 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str104, VK_F8},
-#line 88 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str105, VK_F19},
-#line 41 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str106, VK_RIGHT},
 #line 71 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str101, VK_F1},
+#line 149 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str102, VK_OEM_PA2},
+#line 155 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str103, VK_OEM_COPY},
+#line 78 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str104, VK_F8},
+#line 89 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str105, VK_F19},
+#line 42 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str106, VK_RIGHT},
+#line 72 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str107, VK_F2},
-#line 135 "win32_vk.list"
+#line 136 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str108, VK_OEM_6},
-#line 87 "win32_vk.list"
+#line 88 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str109, VK_F18},
       {-1},
-#line 117 "win32_vk.list"
+#line 118 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str111, VK_VOLUME_UP},
       {-1}, {-1},
-#line 120 "win32_vk.list"
+#line 121 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str114, VK_MEDIA_STOP},
-#line 130 "win32_vk.list"
+#line 131 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str115, VK_OEM_PERIOD},
       {-1},
-#line 161 "win32_vk.list"
+#line 162 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str117, VK_EREOF},
       {-1}, {-1}, {-1},
-#line 114 "win32_vk.list"
+#line 115 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str121, VK_BROWSER_HOME},
-#line 75 "win32_vk.list"
+#line 76 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str122, VK_F6},
       {-1},
-#line 110 "win32_vk.list"
+#line 111 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str124, VK_BROWSER_REFRESH},
       {-1},
-#line 165 "win32_vk.list"
+#line 166 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str126, VK_PA1},
-#line 142 "win32_vk.list"
+#line 143 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str127, VK_PROCESSKEY},
-#line 68 "win32_vk.list"
+#line 69 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str128, VK_DECIMAL},
-#line 132 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str129, VK_OEM_3},
-#line 107 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str130, VK_RMENU},
-#line 106 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str131, VK_LMENU},
-#line 98 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str132, VK_OEM_FJ_MASSHOU},
-#line 54 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str133, VK_NUMPAD0},
-#line 24 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str134, VK_HANGUL},
-#line 63 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str135, VK_NUMPAD9},
-#line 23 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str136, VK_HANGEUL},
-#line 134 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str137, VK_OEM_5},
-#line 149 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str138, VK_OEM_PA3},
-#line 115 "win32_vk.list"
-      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str139, VK_VOLUME_MUTE},
 #line 133 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str129, VK_OEM_3},
+#line 108 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str130, VK_RMENU},
+#line 107 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str131, VK_LMENU},
+#line 99 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str132, VK_OEM_FJ_MASSHOU},
+#line 55 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str133, VK_NUMPAD0},
+#line 25 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str134, VK_HANGUL},
+#line 64 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str135, VK_NUMPAD9},
+#line 24 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str136, VK_HANGEUL},
+#line 135 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str137, VK_OEM_5},
+#line 150 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str138, VK_OEM_PA3},
+#line 116 "win32_vk.list"
+      {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str139, VK_VOLUME_MUTE},
+#line 134 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str140, VK_OEM_4},
-#line 122 "win32_vk.list"
+#line 123 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str141, VK_LAUNCH_MAIL},
-#line 97 "win32_vk.list"
+#line 98 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str142, VK_OEM_FJ_JISHO},
-#line 72 "win32_vk.list"
+#line 73 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str143, VK_F3},
-#line 101 "win32_vk.list"
+#line 102 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str144, VK_OEM_FJ_ROYA},
-#line 100 "win32_vk.list"
+#line 101 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str145, VK_OEM_FJ_LOYA},
       {-1},
-#line 42 "win32_vk.list"
+#line 43 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str147, VK_DOWN},
       {-1},
-#line 153 "win32_vk.list"
+#line 154 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str149, VK_OEM_FINISH},
       {-1},
-#line 74 "win32_vk.list"
+#line 75 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str151, VK_F5},
       {-1},
-#line 136 "win32_vk.list"
+#line 137 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str153, VK_OEM_7},
-#line 73 "win32_vk.list"
+#line 74 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str154, VK_F4},
-#line 86 "win32_vk.list"
+#line 87 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str155, VK_F17},
-#line 55 "win32_vk.list"
+#line 56 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str156, VK_NUMPAD1},
-#line 141 "win32_vk.list"
+#line 142 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str157, VK_ICO_00},
       {-1},
-#line 62 "win32_vk.list"
+#line 63 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str159, VK_NUMPAD8},
       {-1}, {-1},
-#line 56 "win32_vk.list"
+#line 57 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str162, VK_NUMPAD2},
       {-1},
-#line 124 "win32_vk.list"
+#line 125 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str164, VK_LAUNCH_APP1},
-#line 109 "win32_vk.list"
+#line 110 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str165, VK_BROWSER_FORWARD},
       {-1},
-#line 76 "win32_vk.list"
+#line 77 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str167, VK_F7},
       {-1}, {-1},
-#line 125 "win32_vk.list"
+#line 126 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str170, VK_LAUNCH_APP2},
-#line 64 "win32_vk.list"
+#line 65 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str171, VK_MULTIPLY},
       {-1}, {-1},
-#line 45 "win32_vk.list"
+#line 46 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str174, VK_EXECUTE},
       {-1},
-#line 113 "win32_vk.list"
+#line 114 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str176, VK_BROWSER_FAVORITES},
-#line 60 "win32_vk.list"
+#line 61 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str177, VK_NUMPAD6},
       {-1},
-#line 85 "win32_vk.list"
+#line 86 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str179, VK_F16},
       {-1}, {-1},
-#line 79 "win32_vk.list"
+#line 80 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str182, VK_F10},
       {-1}, {-1},
-#line 116 "win32_vk.list"
+#line 117 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str185, VK_VOLUME_DOWN},
       {-1}, {-1},
-#line 89 "win32_vk.list"
+#line 90 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str188, VK_F20},
-#line 119 "win32_vk.list"
+#line 120 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str189, VK_MEDIA_PREV_TRACK},
       {-1},
-#line 33 "win32_vk.list"
+#line 34 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str191, VK_MODECHANGE},
       {-1}, {-1}, {-1}, {-1}, {-1},
-#line 83 "win32_vk.list"
+#line 84 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str197, VK_F14},
-#line 57 "win32_vk.list"
+#line 58 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str198, VK_NUMPAD3},
-#line 11 "win32_vk.list"
+#line 12 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str199, VK_XBUTTON1},
       {-1}, {-1}, {-1},
-#line 93 "win32_vk.list"
+#line 94 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str203, VK_F24},
       {-1},
-#line 12 "win32_vk.list"
+#line 13 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str205, VK_XBUTTON2},
-#line 59 "win32_vk.list"
+#line 60 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str206, VK_NUMPAD5},
       {-1}, {-1},
-#line 58 "win32_vk.list"
+#line 59 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str209, VK_NUMPAD4},
       {-1}, {-1}, {-1}, {-1}, {-1},
-#line 121 "win32_vk.list"
+#line 122 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str215, VK_MEDIA_PLAY_PAUSE},
       {-1},
-#line 123 "win32_vk.list"
+#line 124 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str217, VK_LAUNCH_MEDIA_SELECT},
-#line 80 "win32_vk.list"
+#line 81 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str218, VK_F11},
       {-1},
-#line 139 "win32_vk.list"
+#line 140 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str220, VK_OEM_102},
-#line 118 "win32_vk.list"
+#line 119 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str221, VK_MEDIA_NEXT_TRACK},
-#line 61 "win32_vk.list"
+#line 62 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str222, VK_NUMPAD7},
       {-1},
-#line 90 "win32_vk.list"
+#line 91 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str224, VK_F21},
       {-1},
-#line 82 "win32_vk.list"
+#line 83 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str226, VK_F13},
       {-1}, {-1},
-#line 81 "win32_vk.list"
+#line 82 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str229, VK_F12},
       {-1}, {-1},
-#line 92 "win32_vk.list"
+#line 93 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str232, VK_F23},
       {-1}, {-1},
-#line 91 "win32_vk.list"
+#line 92 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str235, VK_F22},
       {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
-#line 84 "win32_vk.list"
+#line 85 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str242, VK_F15},
       {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1}, {-1},
       {-1}, {-1}, {-1}, {-1},
-#line 69 "win32_vk.list"
+#line 70 "win32_vk.list"
       {(int)(size_t)&((struct stringpool_t *)0)->stringpool_str256, VK_DIVIDE}
     };
+#if (defined __GNUC__ && __GNUC__ + (__GNUC_MINOR__ >= 6) > 4) || (defined __clang__ && __clang_major__ >= 3)
+#pragma GCC diagnostic pop
+#endif
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {
@@ -1386,5 +1483,12 @@ console_win32_vk (register const char *str, register size_t len)
             }
         }
     }
-  return 0;
+  return (struct vktable *) 0;
 }
+#line 168 "win32_vk.list"
+
+/*
+ * Local Variables:
+ * mode: C
+ * End:
+ */

--- a/ext/io/console/win32_vk.list
+++ b/ext/io/console/win32_vk.list
@@ -1,4 +1,5 @@
 %{
+#define UNDEFINED_VK (unsigned short)-1
 struct vktable {short ofs; unsigned short vk;};
 static const struct vktable *console_win32_vk(const char *, size_t);
 %}
@@ -164,3 +165,9 @@ ZOOM, VK_ZOOM
 NONAME, VK_NONAME
 PA1, VK_PA1
 OEM_CLEAR, VK_OEM_CLEAR
+%%
+/*
+ * Local Variables:
+ * mode: C
+ * End:
+ */


### PR DESCRIPTION
Avoid shell single quotes and Ruby command-line globals in the generator. Keep the fallback definition in the gperf input so the same recipe works under both POSIX shells and cmd.exe.