### PR TITLE
Remove stale checks

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -118,22 +118,6 @@ io_path_fallback(VALUE io)
 #define rb_io_path io_path_fallback
 #endif
 
-#ifndef HAVE_RB_IO_GET_WRITE_IO
-static VALUE
-io_get_write_io_fallback(VALUE io)
-{
-    rb_io_t *fptr;
-    GetOpenFile(io, fptr);
-    VALUE wio = fptr->tied_io_for_writing;
-    return wio ? wio : io;
-}
-#define rb_io_get_write_io io_get_write_io_fallback
-#endif
-
-#ifndef DHAVE_RB_SYSERR_FAIL_STR
-# define rb_syserr_fail_str(e, mesg) rb_exc_raise(rb_syserr_new_str(e, mesg))
-#endif
-
 #define sys_fail(io) do { \
     int err = errno; \
     rb_syserr_fail_str(err, rb_io_path(io)); \

--- a/ext/io/console/extconf.rb
+++ b/ext/io/console/extconf.rb
@@ -5,12 +5,12 @@ require 'mkmf'
 # See https://bugs.ruby-lang.org/issues/20345
 MakeMakefile::RbConfig ||= ::RbConfig
 
-have_func("rb_interned_str_cstr")
-have_func("rb_io_path", "ruby/io.h")
-have_func("rb_io_descriptor", "ruby/io.h")
-have_func("rb_io_closed_p", "ruby/io.h")
-have_func("rb_io_open_descriptor", "ruby/io.h")
-have_func("rb_ractor_local_storage_value_newkey")
+have_func("rb_interned_str_cstr") # Ruby 3.0
+have_func("rb_ractor_local_storage_value_newkey") # Ruby 3.0
+have_func("rb_io_descriptor", "ruby/io.h") # Ruby 3.1
+have_func("rb_io_path", "ruby/io.h") # Ruby 3.3
+have_func("rb_io_closed_p", "ruby/io.h") # Ruby 3.3
+have_func("rb_io_open_descriptor", "ruby/io.h") # Ruby 3.3
 
 is_wasi = /wasi/ =~ MakeMakefile::RbConfig::CONFIG["platform"]
 # `ok` can be `true`, `false`, or `nil`:
@@ -44,8 +44,8 @@ when true
   # rb_sym2str: 2.2.0
   if have_macro("HAVE_RUBY_FIBER_SCHEDULER_H")
     $defs << "-D""HAVE_RB_IO_WAIT=1"
-  elsif have_func("rb_scheduler_timeout") # 3.0
-    have_func("rb_io_wait")
+  elsif have_func("rb_scheduler_timeout") # Ruby 3.0 (internal)
+    have_func("rb_io_wait") # Ruby 3.0
   end
   have_func("ttyname_r") or have_func("ttyname")
   create_makefile("io/console") {|conf|

--- a/ext/io/console/extconf.rb
+++ b/ext/io/console/extconf.rb
@@ -5,14 +5,9 @@ require 'mkmf'
 # See https://bugs.ruby-lang.org/issues/20345
 MakeMakefile::RbConfig ||= ::RbConfig
 
-have_func("rb_syserr_fail_str(0, Qnil)") or
-have_func("rb_syserr_new_str(0, Qnil)") or
-  abort
-
 have_func("rb_interned_str_cstr")
 have_func("rb_io_path", "ruby/io.h")
 have_func("rb_io_descriptor", "ruby/io.h")
-have_func("rb_io_get_write_io", "ruby/io.h")
 have_func("rb_io_closed_p", "ruby/io.h")
 have_func("rb_io_open_descriptor", "ruby/io.h")
 have_func("rb_ractor_local_storage_value_newkey")


### PR DESCRIPTION
* rb_io_get_write_io: 1.9.3
* rb_syserr_fail_str: 2.0.0 and backported to 1.9.3