### PR TITLE
Implement FFI console mode support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ task ffi_version_file => "#{name.tr('/', '-')}.gemspec" do |t|
 end
 
 task :build => ffi_version_file
+task :test => ffi_version_file if RUBY_ENGINE == "jruby"
 
 Rake::TestTask.new(:test) do |t|
   if extask

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,7 @@ Rake::TestTask.new(:test) do |t|
   if extask
     t.libs = [extask.lib_dir.chomp("/"+File.dirname(name))]
   end
+  t.libs.unshift "lib/ffi" if RUBY_ENGINE == "jruby"
   t.libs << "test/lib"
   t.ruby_opts << "-rhelper"
   t.options = "--ignore-name=TestIO_Console#test_bad_keyword" if RUBY_ENGINE == "jruby"

--- a/lib/ffi/io/console/bsd_console.rb
+++ b/lib/ffi/io/console/bsd_console.rb
@@ -6,8 +6,6 @@ if RbConfig::CONFIG['host_os'].downcase =~ /darwin/ && FFI::Platform::ARCH !~ /#
   raise LoadError.new("native console on MacOS only supported on #{tested_platforms.join(', ')}")
 end
 
-require_relative 'native_console'
-
 module IO::LibC
   extend FFI::Library
   ffi_lib FFI::Library::LIBC
@@ -172,3 +170,5 @@ module IO::LibC
   attach_function :tcflush, [ :int, :int ], :int
   attach_function :ioctl, [ :int, :ulong, :varargs ], :int
 end
+
+require_relative 'native_console'

--- a/lib/ffi/io/console/linux_console.rb
+++ b/lib/ffi/io/console/linux_console.rb
@@ -6,8 +6,6 @@ unless FFI::Platform::ARCH =~ /#{tested_platforms.join('|')}/
   warn "native console only tested on #{tested_platforms.join(', ')}"
 end
 
-require_relative 'native_console'
-
 module IO::LibC
   extend FFI::Library
   ffi_lib FFI::Library::LIBC
@@ -204,3 +202,5 @@ module IO::LibC
   attach_function :tcflush, [ :int, :int ], :int
   attach_function :ioctl, [ :int, :ulong, :varargs ], :int
 end
+
+require_relative 'native_console'

--- a/lib/ffi/io/console/native_console.rb
+++ b/lib/ffi/io/console/native_console.rb
@@ -8,21 +8,26 @@ class IO
 
     if block_given?
       yield tmp = termios.dup
-      if LibC.tcsetattr(self.fileno, LibC::TCSANOW, tmp) != 0
-        raise SystemCallError.new(respond_to?(:path) ? path : "tcsetattr(TCSANOW)", FFI.errno)
-      end
+      ttymode_set(tmp)
     end
     termios
   end
   private :ttymode
+
+  def ttymode_set(termios)
+    if LibC.tcsetattr(self.fileno, LibC::TCSANOW, termios) != 0
+      raise SystemCallError.new(respond_to?(:path) ? path : "tcsetattr(TCSANOW)", FFI.errno)
+    end
+  end
+  private :ttymode_set
 
   def ttymode_yield(block, **opts, &setup)
     begin
       orig_termios = ttymode { |t| setup.call(t, **opts) }
       block.call(self)
     ensure
-      if orig_termios && LibC.tcsetattr(self.fileno, LibC::TCSANOW, orig_termios) != 0
-        raise SystemCallError.new(respond_to?(:path) ? path : "tcsetattr(TCSANOW)", FFI.errno)
+      if orig_termios
+        ttymode_set(orig_termios)
       end
     end
   end
@@ -81,6 +86,46 @@ class IO
 
   def noecho(&block)
     ttymode_yield(block) { |t| t[:c_lflag] &= ~(TTY_ECHO) }
+  end
+
+  class ConsoleMode
+    attr_reader :termios
+
+    def initialize(t)
+      @termios = t
+    end
+
+    def initialize_copy(m)
+      @termios = m.termios.dup
+    end
+
+    def echo=(echo)
+      if echo
+        @termios[:c_lflag] |= TTY_ECHO
+      else
+        @termios[:c_lflag] &= ~TTY_ECHO
+      end
+    end
+
+    def raw!(min: 1, time: nil, intr: nil)
+      TTY_RAW[@termios, min:, time:, intr:]
+      self
+    end
+
+    def raw(min: 1, time: nil, intr: nil)
+      new_mode = dup
+      TTY_RAW[new_mode.termios, min:, time:, intr:]
+      new_mode
+    end
+  end
+
+  def console_mode
+    ConsoleMode.new(ttymode)
+  end
+
+  def console_mode=(mode)
+    ttymode_set(mode.termios)
+    mode
   end
 
   def winsize

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -270,6 +270,29 @@ class TestIO_Console
     }
   end
 
+  def test_console_mode
+    helper {|m, s|
+      begin
+        original = s.console_mode
+        assert_kind_of(IO::ConsoleMode, original)
+
+        noecho = original.dup
+        noecho.echo = false
+        assert_same(noecho, s.send(:console_mode=, noecho))
+        assert_not_predicate(s, :echo?)
+
+        raw = original.raw
+        assert_not_same(original, raw)
+        assert_same(raw, raw.raw!)
+        assert_same(raw, s.send(:console_mode=, raw))
+        s.print "raw\n"
+        assert_equal("raw\n", m.gets)
+      ensure
+        s.console_mode = original if original
+      end
+    }
+  end
+
   def test_tty_on_pty
     pend "not supported" unless TTY_ENHANCED
 


### PR DESCRIPTION
## Summary

- implement `IO::ConsoleMode` for the FFI backend
- add `IO#console_mode` and `IO#console_mode=`
- load the native console implementation after platform-specific `LibC` definitions
- cover copying, echo control, and raw mode transitions

## Why

The native extension has supported console mode snapshots since 77ed8d5a06b63a297b852145ab75fa4e37d04ee7, but the FFI backend never implemented the equivalent API.  JRuby and TruffleRuby therefore lacked `IO::ConsoleMode` behavior.

Closes #66.

## Testing

- Ubuntu 26.04 arm64 with JRuby 9.4.8.0 via Multipass: 29 tests, 73 assertions, 0 failures, 0 errors, 9 expected pendings
- focused `test_console_mode`: 1 test, 7 assertions, 0 failures, 0 errors
- native extension focused `test_console_mode`: 1 test, 7 assertions, 0 failures, 0 errors
- `git diff --check`
