### PR TITLE
Introduce the `IO::Console` namespace

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,8 +15,10 @@ end
 ffi_version_file = "lib/ffi/#{name}/version.rb"
 task ffi_version_file => "#{name.tr('/', '-')}.gemspec" do |t|
   version = <<~RUBY
-    class IO::ConsoleMode
-      VERSION = "#{Bundler::GemHelper.instance.gemspec.version}"
+    class IO
+      module Console
+        VERSION = "#{Bundler::GemHelper.instance.gemspec.version}"
+      end
     end
   RUBY
   unless (File.read(t.name) rescue nil) == version

--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -2102,8 +2102,21 @@ InitVM_console(void)
     }
     {
 	/* :nodoc: */
-        cConmode = rb_define_class_under(rb_cIO, "ConsoleMode", rb_cObject);
-        rb_define_const(cConmode, "VERSION", rb_obj_freeze(rb_str_new_cstr(IO_CONSOLE_VERSION)));
+	VALUE mConsole = rb_define_module_under(rb_cIO, "Console");
+	VALUE version = rb_obj_freeze(rb_str_new_cstr(IO_CONSOLE_VERSION));
+	ID cid, deprecate_constant = rb_intern_const("deprecate_constant");
+	rb_define_const(mConsole, "VERSION", version);
+	/* :nodoc: */
+	cConmode = rb_define_class_under(mConsole, "Mode", rb_cObject);
+
+	/* old internal names; do not use */
+	cid = rb_intern_const("ConsoleMode");
+	rb_const_set(rb_cIO, cid, cConmode);
+	rb_funcall(rb_cIO, deprecate_constant, 1, ID2SYM(cid));
+	cid = rb_intern_const("VERSION");
+	rb_const_set(cConmode, cid, version);
+	rb_funcall(cConmode, deprecate_constant, 1, ID2SYM(cid));
+
         rb_define_alloc_func(cConmode, conmode_alloc);
         rb_undef_method(cConmode, "initialize");
         rb_define_method(cConmode, "initialize_copy", conmode_init_copy, 1);

--- a/lib/ffi/io/console.rb
+++ b/lib/ffi/io/console.rb
@@ -24,6 +24,18 @@ require 'rbconfig'
 require_relative 'console/version'
 require_relative 'console/common'
 
+class IO
+  module Console
+    class Mode
+      VERSION = Console::VERSION
+      deprecate_constant :VERSION
+    end
+  end
+
+  ConsoleMode = Console::Mode
+  deprecate_constant :ConsoleMode
+end
+
 libs = []
 # If Linux or BSD, try to load the native version
 case RbConfig::CONFIG['host_os'].downcase

--- a/lib/ffi/io/console/bsd_console.rb
+++ b/lib/ffi/io/console/bsd_console.rb
@@ -6,7 +6,7 @@ if RbConfig::CONFIG['host_os'].downcase =~ /darwin/ && FFI::Platform::ARCH !~ /#
   raise LoadError.new("native console on MacOS only supported on #{tested_platforms.join(', ')}")
 end
 
-module IO::LibC
+module IO::Console::LibC
   extend FFI::Library
   ffi_lib FFI::Library::LIBC
 

--- a/lib/ffi/io/console/linux_console.rb
+++ b/lib/ffi/io/console/linux_console.rb
@@ -6,7 +6,7 @@ unless FFI::Platform::ARCH =~ /#{tested_platforms.join('|')}/
   warn "native console only tested on #{tested_platforms.join(', ')}"
 end
 
-module IO::LibC
+module IO::Console::LibC
   extend FFI::Library
   ffi_lib FFI::Library::LIBC
 

--- a/lib/ffi/io/console/native_console.rb
+++ b/lib/ffi/io/console/native_console.rb
@@ -1,5 +1,5 @@
 # Common logic that uses native calls for console
-class IO
+module IO::Console
   def ttymode
     termios = LibC::Termios.new
     if LibC.tcgetattr(self.fileno, termios) != 0
@@ -88,7 +88,7 @@ class IO
     ttymode_yield(block) { |t| t[:c_lflag] &= ~(TTY_ECHO) }
   end
 
-  class ConsoleMode
+  class Mode
     attr_reader :termios
 
     def initialize(t)
@@ -120,7 +120,7 @@ class IO
   end
 
   def console_mode
-    ConsoleMode.new(ttymode)
+    Mode.new(ttymode)
   end
 
   def console_mode=(mode)
@@ -172,4 +172,8 @@ class IO
   def ioflush
     raise SystemCallError.new("tcflush(TCIOFLUSH)", FFI.errno) unless LibC.tcflush(self.fileno, LibC::TCIOFLUSH) == 0
   end
+end
+
+class IO
+  include Console
 end

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -8,6 +8,14 @@ end
 
 class TestIO_Console < Test::Unit::TestCase
   HOST_OS = RbConfig::CONFIG['host_os']
+
+  def test_version
+    assert_kind_of(String, IO::Console::VERSION)
+    EnvUtil.suppress_warning do
+      assert_same(IO::Console::VERSION, IO::Console::Mode::VERSION)
+    end
+  end
+
   private def host_os?(os)
     HOST_OS =~ os
   end
@@ -274,7 +282,10 @@ class TestIO_Console
     helper {|m, s|
       begin
         original = s.console_mode
-        assert_kind_of(IO::ConsoleMode, original)
+        assert_kind_of(IO::Console::Mode, original)
+        EnvUtil.suppress_warning do
+          assert_same(IO::Console::Mode, IO.const_get(:ConsoleMode))
+        end
 
         noecho = original.dup
         noecho.echo = false


### PR DESCRIPTION
Isolate console modes and version information from `IO` into a common namespace.