### PR TITLE
Fix stty redirection on JRuby

### DIFF
--- a/lib/ffi/io/console/stty_console.rb
+++ b/lib/ffi/io/console/stty_console.rb
@@ -17,8 +17,10 @@ class IO
     raise Errno::ENOTTY, inspect if !tty?
 
     IO.pipe do |re, we|
-      IO.popen([Console::STTY, *args, in: fileno, err: we], &:read)
+      input = dup # workaround for JRuby
+      IO.popen([Console::STTY, *args, in: input, err: we], &:read)
     ensure
+      input&.close
       unless $?.success?
         we.close
         error = re.read

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -308,6 +308,22 @@ class TestIO_Console
     }
   end
 
+  def test_stty_redirect_stdout
+    omit unless IO.private_method_defined?(:_io_console_stty)
+
+    helper do |_, s|
+      stdout = STDOUT.dup
+      begin
+        STDOUT.reopen(s)
+        mode = STDOUT.__send__(:_io_console_stty, "-g")
+      ensure
+        STDOUT.reopen(stdout)
+        stdout.close
+      end
+      assert_not_empty(mode)
+    end
+  end
+
   def test_tty_on_pty
     pend "not supported" unless TTY_ENHANCED
 


### PR DESCRIPTION
Duplicate the terminal descriptor so `IO.popen` can capture output without redirect conflicts.

Fix https://github.com/ruby/io-console/issues/145.