### PR TITLE
Avoid timing race in `noecho` test 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -48,6 +48,9 @@ task "build" => %w[rdoc:coverage build:java]
 
 task "build:java" => "date_epoch"
 
+# For old the RDoc included with Ruby 2.6, which doesn't define this task.
+task "rdoc:coverage"
+
 # Keep RDoc::Task's coverage check from exiting the Rake process.
 coverage_task = Rake::Task["rdoc:coverage"].actions.shift
 task "rdoc:coverage" do |*t|

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -211,7 +211,8 @@ class TestIO_Console
       s.noecho {
 	assert_not_send([s, :echo?])
 	m.print "a"
-	sleep 0.1
+	m.flush
+	assert_equal("a", s.getch)
       }
       m.print "b"
       assert_equal("b", m.readpartial(10))

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -309,8 +309,6 @@ class TestIO_Console
   end
 
   def test_stty_redirect_stdout
-    omit unless IO.private_method_defined?(:_io_console_stty)
-
     helper do |_, s|
       stdout = STDOUT.dup
       begin
@@ -322,7 +320,7 @@ class TestIO_Console
       end
       assert_not_empty(mode)
     end
-  end
+  end if IO.private_method_defined?(:_io_console_stty)
 
   def test_tty_on_pty
     pend "not supported" unless TTY_ENHANCED


### PR DESCRIPTION
Read the input before restoring echo mode so slow platforms do not process it after echo has been re-enabled.
