### PR TITLE
Use ttyname_r return codes for errors

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -2238,17 +2238,17 @@ console_ttyname(VALUE io)
 	char termname[1024], *tn = termname;
 	size_t size = sizeof(termname);
 	int e;
-	if (ttyname_r(fd, tn, size) == 0)
+	if ((e = ttyname_r(fd, tn, size)) == 0)
 	    return rb_interned_str_cstr(tn);
-	if ((e = errno) == ERANGE) {
+	if (e == ERANGE) {
 	    VALUE s = rb_str_new(0, size);
 	    while (1) {
 		tn = RSTRING_PTR(s);
 		size = rb_str_capacity(s);
-		if (ttyname_r(fd, tn, size) == 0) {
+		if ((e = ttyname_r(fd, tn, size)) == 0) {
 		    return rb_str_to_interned_str(rb_str_resize(s, strlen(tn)));
 		}
-		if ((e = errno) != ERANGE) break;
+		if (e != ERANGE) break;
 		if ((size *= 2) >= INT_MAX/2) break;
 		rb_str_resize(s, size);
 	    }


### PR DESCRIPTION
## Summary

Use the POSIX `ttyname_r` return value for error handling instead of reading potentially stale `errno`.

## Reproduction

A focused external native model stubs `ttyname_r` to return `ERANGE` and another error while leaving `errno` unrelated; current code follows the stale value and the candidate follows the function result.

## Verification

- release/cumulative candidate: 36 tests / 143 assertions
- current upstream: 35 tests / 144 assertions
- native compilation, focused native model, RDoc, package inspection, syntax and Rails 8.1.3.1 loading

## Compatibility

No public API change. This aligns error handling with the POSIX contract. Prepared with AI-assisted source review; no repository tests were changed.
