### PR TITLE
Correct ttyname documentation

### DIFF
--- a/ext/io/console/console.c
+++ b/ext/io/console/console.c
@@ -2223,7 +2223,7 @@ io_getpass(int argc, VALUE *argv, VALUE io)
  * call-seq:
  *   io.ttyname       -> string or nil
  *
- * Returns name of associated terminal (tty) if +io+ is not a tty.
+ * Returns name of associated terminal (tty) if +io+ is a tty.
  * Returns +nil+ otherwise.
  */
 static VALUE


### PR DESCRIPTION
## Summary

Correct the reversed `IO#ttyname` documentation: it returns the terminal name when the IO is a tty and `nil` otherwise.

## Reproduction

The implementation first returns `nil` when `isatty(fd)` is false, which is the opposite of the current sentence.

## Verification

- RDoc builds with 100% documented coverage
- release/cumulative candidate: 36 tests / 143 assertions
- current upstream: 35 tests / 144 assertions

## Compatibility

Documentation-only; no runtime or public API change. Prepared with AI-assisted source review; no repository tests were changed.
