### PR TITLE
Honor JRuby raw mode options

### DIFF
--- a/jruby/lib/io/console/backend/ffi/termios.rb
+++ b/jruby/lib/io/console/backend/ffi/termios.rb
@@ -105,10 +105,10 @@ module IO::Console
   TTY_RAW = Proc.new do |t, min: 1, time: nil, intr: nil|
     LibC.cfmakeraw(t.pointer)
     t[:c_lflag] &= ~(LibC::ECHOE|LibC::ECHOK)
-    if min >= 0
+    if min && min >= 0
       t[:c_cc][LibC::VMIN] = min
     end
-    t[:c_cc][LibC::VTIME] = (time&.to_i || 0) * 10
+    t[:c_cc][LibC::VTIME] = ((time || 0) * 10).to_i
     if intr
       t[:c_iflag] |= LibC::BRKINT
       t[:c_lflag] |= LibC::ISIG
@@ -120,8 +120,9 @@ module IO::Console
     ttymode_yield(block, min:, time:, intr:, &TTY_RAW)
   end
 
-  def raw!(*)
-    ttymode(&TTY_RAW)
+  def raw!(*, min: 1, time: nil, intr: nil)
+    ttymode { |t| TTY_RAW.call(t, min:, time:, intr:) }
+    self
   end
 
   TTY_COOKED = Proc.new do |t|

--- a/jruby/lib/io/console/backend/stty.rb
+++ b/jruby/lib/io/console/backend/stty.rb
@@ -30,7 +30,7 @@ class IO::Console::Mode
 
   def raw!(min: 1, time: nil, intr: nil)
     @args << 'raw'
-    @args.push('min', min.to_s) if min >= 0
+    @args.push('min', min.to_s) if min && min >= 0
     @args.push('time', ((time || 0) * 10).to_i.to_s)
     @args.concat(%w[brkint isig opost]) if intr
     self
@@ -72,8 +72,9 @@ class IO
     self.console_mode = saved if saved
   end
 
-  def raw!(*)
-    _io_console_stty('raw')
+  def raw!(*, min: 1, time: nil, intr: nil)
+    self.console_mode = console_mode.raw(min:, time:, intr:)
+    self
   end
 
   def cooked(*)


### PR DESCRIPTION
## Summary

Forward `min:`, `time:` and `intr:` through JRuby's mutating raw-mode paths, preserve fractional timeout conversion, accept `min: nil`, and return the receiver from `raw!`.

## Reproduction

Focused external FFI/stty models show that current `raw!` discards every option, truncates fractional timeout before converting to deciseconds, and returns backend state rather than the IO receiver.

## Verification

- external JRuby-backend option/return models
- release/cumulative candidate: 36 tests / 143 assertions
- current upstream: 35 tests / 144 assertions
- syntax, Java/native package builds and Rails 8.1.3.1 loading

## Compatibility

Matches MRI's existing option and return contracts. JRuby was modeled but is unavailable locally; current upstream CI is green on JRuby. Prepared with AI-assisted source review; no repository tests were changed.
