### PR TITLE
Generate the version file before Java builds

### DIFF
--- a/rakelib/build_java.rake
+++ b/rakelib/build_java.rake
@@ -1,7 +1,7 @@
 helper = Bundler::GemHelper.instance
 
 java_pkg = nil
-task 'build:java' => 'date_epoch' do |t|
+task 'build:java' => ['jruby/lib/io/console/version.rb', 'date_epoch'] do |t|
   java_pkg = helper.build_java_gem
 end
 


### PR DESCRIPTION
## Summary

Make `build:java` depend on its generated JRuby version file.

## Reproduction

A clean checkout currently fails standalone `rake build:java` because the Java gemspec loads a missing generated version file. Declaring the existing file task makes the command self-contained.

## Verification

- clean standalone `build:java` succeeds
- candidate native and Java gems build with expected contents
- release/cumulative candidate: 36 tests / 143 assertions
- current upstream: 35 tests / 144 assertions

## Compatibility

Build-task dependency only; runtime and package interfaces are unchanged. Prepared with AI-assisted source review; no repository tests were changed.
