### PR TITLE
Accept mode arguments for `tty?` in the stty backend

### DIFF
--- a/jruby/lib/io/console/backend/stty.rb
+++ b/jruby/lib/io/console/backend/stty.rb
@@ -208,4 +208,23 @@ class IO
 
   def ioflush
   end
+
+  module PlatformStty           # :nodoc:
+    def tty?(*modes)
+      modes.each do |mode|
+        case mode
+        when nil
+        when :any
+        when Symbol
+          raise ArgumentError, "unknown tty type: #{mode.inspect}"
+        else
+          raise TypeError, "wrong argument type #{mode.class} (expected Symbol)"
+        end
+      end
+      super()
+    end
+  end
+  private_constant :PlatformStty
+
+  prepend PlatformStty
 end

--- a/test/io/console/test_io_console.rb
+++ b/test/io/console/test_io_console.rb
@@ -78,8 +78,6 @@ class TestIO_Console < Test::Unit::TestCase
   TTY_MODE_STTY = IO.private_method_defined?(:_io_console_stty)
 
   def test_stty_mode_arguments
-    omit "stty backend only" unless TTY_MODE_STTY
-
     mode = IO::Console::Mode.new(
       "saved\n",
       "echo icanon isig opost; min = 1; time = 0;",
@@ -87,7 +85,7 @@ class TestIO_Console < Test::Unit::TestCase
     mode.raw!(min: 2, time: 0.3)
 
     assert_equal(["saved", "raw", "min", "2", "time", "3"], mode.arguments)
-  end
+  end if TTY_MODE_STTY
 
   def test_tty?
     pend "not supported" unless TTY_ENHANCED
@@ -346,7 +344,7 @@ class TestIO_Console
       end
       assert_not_empty(mode)
     end
-  end if IO.private_method_defined?(:_io_console_stty)
+  end if TTY_MODE_STTY
 
   def test_tty_on_pty
     pend "not supported" unless TTY_ENHANCED


### PR DESCRIPTION
Only the `:any` mode, which is equivalent to the default `nil`.
